### PR TITLE
Fix warnings about setting attributes

### DIFF
--- a/monokai-pro-theme.el
+++ b/monokai-pro-theme.el
@@ -102,7 +102,7 @@
      (fringe                                       :background bg)
 
      ;;(gui-element                                  :background bg+1)
-     (header-line                                  :background nil :inherit mode-line)
+     (header-line                                  :background unspecified :inherit mode-line)
 
      ;; TODO: This matches highlight and findHighlight, but we may want
      ;; to look at findHighlightForeground which is simply bg.
@@ -161,7 +161,7 @@
 
 ;;;; mode-line
      (mode-line                                    :foreground fg-2 :background bg+1)
-     (mode-line-buffer-id                          :foreground yellow :background nil)
+     (mode-line-buffer-id                          :foreground yellow :background unspecified)
      (mode-line-emphasis                           :foreground fg-1)
      (mode-line-highlight                          :foreground fg :box nil :weight bold)
      (mode-line-inactive                           :foreground fg-2 :background bg+2)


### PR DESCRIPTION
Thanks for such a great theme! I love monokai (and its variants) so much that I use it everywhere including the Emacs. 

However I found some warnings in the `*Messages*` buffer while Emacs starts and loads the `monokai-pro` theme. Warnings are like the following:

```plain
Warning: setting attribute ‘:background’ of face ‘mode-line-buffer-id’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘header-line’: nil value is invalid, use ‘unspecified’ instead.
```

Fix them by applying the suggestions. 

> Apart from the values given below, each face attribute can have the value unspecified. This special value means that the face doesn’t specify that attribute directly.

Reference: [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html).